### PR TITLE
feat(admin): add analytics dashboard with stats tracking

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -16,6 +16,7 @@ import AdminDashboardPage from "./pages/AdminDashboardPage";
 import JobDescriptionFormPage from "./pages/JobDescriptionFormPage";
 import UsersPage from "./pages/UsersPage";
 import UserDetailPage from "./pages/UserDetailPage";
+import AnalyticsPage from "./pages/AnalyticsPage";
 import AdminRoute from "./components/AdminRoute";
 
 // Form Components
@@ -98,6 +99,14 @@ function App() {
             element={
               <AdminRoute>
                 <UserDetailPage />
+              </AdminRoute>
+            }
+          />
+          <Route
+            path="/admin/analytics"
+            element={
+              <AdminRoute>
+                <AnalyticsPage />
               </AdminRoute>
             }
           />

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -202,6 +202,11 @@ function Navbar() {
                       Users
                     </Link>
                   </li>
+                  <li>
+                    <Link className="dropdown-item" to="/admin/analytics">
+                      Analytics
+                    </Link>
+                  </li>
                 </ul>
               </li>
             )}

--- a/client/src/pages/AnalyticsPage.css
+++ b/client/src/pages/AnalyticsPage.css
@@ -1,0 +1,29 @@
+.completion-circle {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.analytics-page .card {
+  transition: transform 0.2s ease-in-out;
+}
+
+.analytics-page .card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.analytics-page h3 {
+  font-size: 2.5rem;
+  font-weight: 700;
+}
+
+.analytics-page h2 {
+  font-size: 2rem;
+  font-weight: 700;
+}

--- a/client/src/pages/AnalyticsPage.jsx
+++ b/client/src/pages/AnalyticsPage.jsx
@@ -1,0 +1,163 @@
+import React, { useState, useEffect } from 'react';
+import { adminService } from '../services/adminApi';
+import './AnalyticsPage.css';
+
+const AnalyticsPage = () => {
+  const [stats, setStats] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetchStats();
+  }, []);
+
+  const fetchStats = async () => {
+    try {
+      setLoading(true);
+      const response = await adminService.getAnalytics();
+      setStats(response.data);
+    } catch {
+      setError('Failed to fetch analytics data.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getCompletionColor = (percentage) => {
+    if (percentage >= 70) return 'text-success';
+    if (percentage >= 40) return 'text-warning';
+    return 'text-danger';
+  };
+
+  if (loading) {
+    return (
+      <div className="text-center mt-5">
+        <div className="spinner-border text-primary" role="status">
+          <span className="visually-hidden">Loading...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container mt-4">
+        <div className="alert alert-danger" role="alert">
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="analytics-page container-fluid py-4">
+      <header className="mb-4">
+        <h1>Analytics Dashboard</h1>
+        <p className="text-muted">Platform overview and statistics</p>
+      </header>
+
+      <div className="row g-4 mb-4">
+        <div className="col-md-6 col-lg-3">
+          <div className="card h-100">
+            <div className="card-body text-center">
+              <h3 className="text-primary mb-2">{stats?.totalUsers || 0}</h3>
+              <p className="mb-0 text-muted">Total Users</p>
+            </div>
+            <div className="card-footer bg-transparent">
+              <small className="text-muted">
+                {stats?.totalStudents || 0} students, {stats?.totalAdmins || 0} admins
+              </small>
+            </div>
+          </div>
+        </div>
+
+        <div className="col-md-6 col-lg-3">
+          <div className="card h-100">
+            <div className="card-body text-center">
+              <h3 className="text-success mb-2">{stats?.activeUsers || 0}</h3>
+              <p className="mb-0 text-muted">Active Users</p>
+            </div>
+            <div className="card-footer bg-transparent">
+              <small className="text-muted">
+                {stats?.totalUsers - stats?.activeUsers || 0} inactive/suspended
+              </small>
+            </div>
+          </div>
+        </div>
+
+        <div className="col-md-6 col-lg-3">
+          <div className="card h-100">
+            <div className="card-body text-center">
+              <h3 className="text-info mb-2">{stats?.totalJobs || 0}</h3>
+              <p className="mb-0 text-muted">Job Descriptions</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="col-md-6 col-lg-3">
+          <div className="card h-100">
+            <div className="card-body text-center">
+              <h3 className="text-warning mb-2">{stats?.totalMatches || 0}</h3>
+              <p className="mb-0 text-muted">Total Matches</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="row g-4 mb-4">
+        <div className="col-md-6">
+          <div className="card h-100">
+            <div className="card-header bg-light">
+              <h5 className="mb-0">Resume Completion</h5>
+            </div>
+            <div className="card-body text-center">
+              <div className="completion-circle mx-auto mb-3">
+                <h2 className={`mb-0 ${getCompletionColor(stats?.avgResumeCompletion || 0)}`}>
+                  {stats?.avgResumeCompletion || 0}%
+                </h2>
+              </div>
+              <p className="text-muted mb-0">Average Resume Completeness</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="col-md-6">
+          <div className="card h-100">
+            <div className="card-header bg-light">
+              <h5 className="mb-0">Match Quality</h5>
+            </div>
+            <div className="card-body text-center">
+              <div className="completion-circle mx-auto mb-3">
+                <h2 className="text-primary mb-0">
+                  {stats?.avgMatchScore || 0}
+                </h2>
+              </div>
+              <p className="text-muted mb-0">Average Match Score (0-1)</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-header bg-light">
+          <h5 className="mb-0">Top Skills</h5>
+        </div>
+        <div className="card-body">
+          {stats?.topSkills && stats.topSkills.length > 0 ? (
+            <div className="d-flex flex-wrap gap-2">
+              {stats.topSkills.map((skill, index) => (
+                <span key={index} className="badge bg-secondary fs-6">
+                  {skill.name} <span className="badge bg-light text-dark">{skill.count}</span>
+                </span>
+              ))}
+            </div>
+          ) : (
+            <p className="text-muted mb-0">No skills data available yet.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AnalyticsPage;

--- a/client/src/services/adminApi.js
+++ b/client/src/services/adminApi.js
@@ -54,6 +54,9 @@ const adminService = {
   getUserById: (id) => adminApi.get(`/users/${id}`),
   updateUserRole: (id, role) => adminApi.put(`/users/${id}/role`, { role }),
   updateUserStatus: (id, status) => adminApi.put(`/users/${id}/status`, { status }),
+
+  // Analytics
+  getAnalytics: () => adminApi.get('/analytics/dashboard'),
 };
 
 export { adminApi, adminService };

--- a/server/features/analytics/analytics.controller.js
+++ b/server/features/analytics/analytics.controller.js
@@ -1,0 +1,56 @@
+const service = require('./analytics.service');
+
+const getDashboard = async (req, res) => {
+  try {
+    const stats = await service.getDashboardStats();
+    const topSkills = await service.getTopSkills(10);
+    res.json({ ...stats, topSkills });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+};
+
+const getUserStats = async (req, res) => {
+  try {
+    const stats = await service.getUserStats();
+    res.json(stats);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+};
+
+const getJobStats = async (req, res) => {
+  try {
+    const stats = await service.getJobStats();
+    res.json(stats);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+};
+
+const getMatchStats = async (req, res) => {
+  try {
+    const stats = await service.getMatchStats();
+    res.json(stats);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+};
+
+const getTopSkills = async (req, res) => {
+  try {
+    const limit = parseInt(req.query.limit) || 10;
+    const skills = await service.getTopSkills(limit);
+    res.json(skills);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+};
+
+module.exports = {
+  getDashboard,
+  getUserStats,
+  getJobStats,
+  getMatchStats,
+  getTopSkills
+};

--- a/server/features/analytics/analytics.repository.js
+++ b/server/features/analytics/analytics.repository.js
@@ -1,0 +1,138 @@
+const { User, JobDescription, MatchHistory, Heading } = require('../../models');
+const { Sequelize } = require('sequelize');
+
+const countUsers = async () => {
+  return await User.count();
+};
+
+const countStudents = async () => {
+  return await User.count({ where: { role: 'student' } });
+};
+
+const countAdmins = async () => {
+  return await User.count({ where: { role: 'administrator' } });
+};
+
+const countActiveUsers = async () => {
+  return await User.count({ where: { status: 'active' } });
+};
+
+const countJobs = async () => {
+  return await JobDescription.count();
+};
+
+const countMatchHistory = async () => {
+  return await MatchHistory.count();
+};
+
+const getAverageMatchScore = async () => {
+  const result = await MatchHistory.findOne({
+    attributes: [
+      [Sequelize.fn('AVG', Sequelize.col('match_score')), 'avgScore']
+    ]
+  });
+  return result ? parseFloat(result.dataValues.avgScore) || 0 : 0;
+};
+
+const getTopSkills = async (limit = 10) => {
+  const { Skill } = require('../../models');
+  const skills = await Skill.findAll({
+    attributes: [
+      'name',
+      [Sequelize.fn('COUNT', Sequelize.col('name')), 'count']
+    ],
+    group: ['name'],
+    order: [[Sequelize.literal('count'), 'DESC']],
+    limit
+  });
+  return skills.map(s => ({ name: s.name, count: parseInt(s.dataValues.count) }));
+};
+
+const getMatchHistoryByJob = async (jobId) => {
+  return await MatchHistory.findAll({
+    where: { jobId },
+    include: [
+      { model: User, as: 'user', attributes: ['id', 'name', 'email'] }
+    ],
+    order: [['matchScore', 'DESC']],
+    limit: 20
+  });
+};
+
+const getMatchHistoryByUser = async (userId) => {
+  return await MatchHistory.findAll({
+    where: { userId },
+    include: [
+      { model: JobDescription, as: 'job', attributes: ['id', 'title'] }
+    ],
+    order: [['matchScore', 'DESC']]
+  });
+};
+
+const createMatchHistory = async (jobId, userId, matchScore) => {
+  return await MatchHistory.create({
+    jobId,
+    userId,
+    matchScore,
+    matchedAt: new Date()
+  });
+};
+
+const getUserResumeCompletion = async (userId) => {
+  const heading = await Heading.findOne({ where: { userId } });
+  const { Experience, Education, Project, Skill, Certification, Achievement } = require('../../models');
+  
+  const counts = await Promise.all([
+    Experience.count({ where: { userId } }),
+    Education.count({ where: { userId } }),
+    Project.count({ where: { userId } }),
+    Skill.count({ where: { userId } }),
+    Certification.count({ where: { userId } }),
+    Achievement.count({ where: { userId } })
+  ]);
+
+  const completed = [
+    heading ? 1 : 0,
+    counts[0] > 0 ? 1 : 0,
+    counts[1] > 0 ? 1 : 0,
+    counts[2] > 0 ? 1 : 0,
+    counts[3] > 0 ? 1 : 0,
+    counts[4] > 0 ? 1 : 0,
+    counts[5] > 0 ? 1 : 0
+  ].filter(Boolean).length;
+
+  return {
+    total: 7,
+    completed,
+    percentage: Math.round((completed / 7) * 100)
+  };
+};
+
+const getAverageResumeCompletion = async () => {
+  const users = await User.findAll({ where: { role: 'student' } });
+  if (users.length === 0) return 0;
+
+  let totalCompletion = 0;
+  for (const user of users) {
+    const completion = await getUserResumeCompletion(user.id);
+    totalCompletion += completion.percentage;
+  }
+
+  return Math.round(totalCompletion / users.length);
+};
+
+module.exports = {
+  countUsers,
+  countStudents,
+  countAdmins,
+  countActiveUsers,
+  countJobs,
+  countMatchHistory,
+  getAverageMatchScore,
+  getTopSkills,
+  getMatchHistoryByJob,
+  getMatchHistoryByUser,
+  createMatchHistory,
+  getUserResumeCompletion,
+  getAverageResumeCompletion
+};

--- a/server/features/analytics/analytics.routes.js
+++ b/server/features/analytics/analytics.routes.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('./analytics.controller');
+const authenticateToken = require('../../middleware/auth');
+const authorizeRoles = require('../../middleware/roles');
+
+router.get('/dashboard', authenticateToken, authorizeRoles('administrator'), controller.getDashboard);
+router.get('/users', authenticateToken, authorizeRoles('administrator'), controller.getUserStats);
+router.get('/jobs', authenticateToken, authorizeRoles('administrator'), controller.getJobStats);
+router.get('/matches', authenticateToken, authorizeRoles('administrator'), controller.getMatchStats);
+router.get('/skills', authenticateToken, authorizeRoles('administrator'), controller.getTopSkills);
+
+module.exports = router;

--- a/server/features/analytics/analytics.service.js
+++ b/server/features/analytics/analytics.service.js
@@ -1,0 +1,108 @@
+const repository = require('./analytics.repository');
+
+const getDashboardStats = async () => {
+  const [
+    totalUsers,
+    totalStudents,
+    totalAdmins,
+    activeUsers,
+    totalJobs,
+    totalMatches,
+    avgMatchScore,
+    avgCompletion
+  ] = await Promise.all([
+    repository.countUsers(),
+    repository.countStudents(),
+    repository.countAdmins(),
+    repository.countActiveUsers(),
+    repository.countJobs(),
+    repository.countMatchHistory(),
+    repository.getAverageMatchScore(),
+    repository.getAverageResumeCompletion()
+  ]);
+
+  return {
+    totalUsers,
+    totalStudents,
+    totalAdmins,
+    activeUsers,
+    totalJobs,
+    totalMatches,
+    avgMatchScore: avgMatchScore.toFixed(2),
+    avgResumeCompletion: avgCompletion
+  };
+};
+
+const getUserStats = async () => {
+  const [total, students, admins, active] = await Promise.all([
+    repository.countUsers(),
+    repository.countStudents(),
+    repository.countAdmins(),
+    repository.countActiveUsers()
+  ]);
+
+  return {
+    total,
+    students,
+    admins,
+    active,
+    inactive: total - active
+  };
+};
+
+const getJobStats = async () => {
+  const total = await repository.countJobs();
+  return { total };
+};
+
+const getMatchStats = async () => {
+  const [total, avgScore] = await Promise.all([
+    repository.countMatchHistory(),
+    repository.getAverageMatchScore()
+  ]);
+
+  return {
+    total,
+    avgScore: avgScore.toFixed(2)
+  };
+};
+
+const getTopSkills = async (limit = 10) => {
+  return await repository.getTopSkills(limit);
+};
+
+const recordMatch = async (jobId, userId, matchScore) => {
+  return await repository.createMatchHistory(jobId, userId, matchScore);
+};
+
+const getMatchHistoryForJob = async (jobId) => {
+  const history = await repository.getMatchHistoryByJob(jobId);
+  return history.map(h => ({
+    userId: h.userId,
+    userName: h.user?.name || 'Unknown',
+    userEmail: h.user?.email || '',
+    matchScore: h.matchScore,
+    matchedAt: h.matchedAt
+  }));
+};
+
+const getMatchHistoryForUser = async (userId) => {
+  const history = await repository.getMatchHistoryByUser(userId);
+  return history.map(h => ({
+    jobId: h.jobId,
+    jobTitle: h.job?.title || 'Unknown',
+    matchScore: h.matchScore,
+    matchedAt: h.matchedAt
+  }));
+};
+
+module.exports = {
+  getDashboardStats,
+  getUserStats,
+  getJobStats,
+  getMatchStats,
+  getTopSkills,
+  recordMatch,
+  getMatchHistoryForJob,
+  getMatchHistoryForUser
+};

--- a/server/features/job-description/jobDescription.service.js
+++ b/server/features/job-description/jobDescription.service.js
@@ -3,6 +3,7 @@ const { SyncService } = require('../ml/sync.service');
 const mlClient = require('../ml/ml.client');
 const userRepository = require('../user/user.repository');
 const headingRepository = require('../resume/heading/heading.repository');
+const analyticsService = require('../analytics/analytics.service');
 
 const getJobDescriptions = async () => {
   return jobDescriptionRepository.findAll();
@@ -56,12 +57,13 @@ const matchJob = async (jobId, topN = 10) => {
     return acc;
   }, {});
 
-  return result.matches.map((match) => {
+  const matches = result.matches.map((match) => {
     const userId = match.user_id;
     const user = userMap[userId];
     const heading = headingMap[userId];
     return {
       score: match.score,
+      userId,
       user: {
         id: userId,
         name: user ? user.name : heading ? heading.name : "N/A",
@@ -70,6 +72,16 @@ const matchJob = async (jobId, topN = 10) => {
       },
     };
   });
+
+  for (const match of matches) {
+    try {
+      await analyticsService.recordMatch(parseInt(jobId), match.userId, match.score);
+    } catch (err) {
+      console.error(`Failed to record match history for job ${jobId}, user ${match.userId}:`, err.message);
+    }
+  }
+
+  return matches;
 };
 
 module.exports = {

--- a/server/migrations/20260322210718-create-match-history.js
+++ b/server/migrations/20260322210718-create-match-history.js
@@ -1,0 +1,60 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('MatchHistories', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      jobId: {
+        type: Sequelize.INTEGER,
+        field: 'job_id',
+        references: {
+          model: 'JobDescriptions',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      userId: {
+        type: Sequelize.INTEGER,
+        field: 'user_id',
+        references: {
+          model: 'Users',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      matchScore: {
+        type: Sequelize.FLOAT,
+        field: 'match_score'
+      },
+      matchedAt: {
+        type: Sequelize.DATE,
+        field: 'matched_at',
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      }
+    });
+
+    await queryInterface.addIndex('MatchHistories', ['job_id']);
+    await queryInterface.addIndex('MatchHistories', ['user_id']);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('MatchHistories');
+  }
+};

--- a/server/models/matchHistory.js
+++ b/server/models/matchHistory.js
@@ -1,0 +1,37 @@
+'use strict';
+const { Model } = require('sequelize');
+
+module.exports = (sequelize, DataTypes) => {
+  class MatchHistory extends Model {
+    static associate(models) {
+      MatchHistory.belongsTo(models.User, { foreignKey: 'userId', as: 'user' });
+      MatchHistory.belongsTo(models.JobDescription, { foreignKey: 'jobId', as: 'job' });
+    }
+  }
+
+  MatchHistory.init({
+    jobId: {
+      type: DataTypes.INTEGER,
+      field: 'job_id'
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      field: 'user_id'
+    },
+    matchScore: {
+      type: DataTypes.FLOAT,
+      field: 'match_score'
+    },
+    matchedAt: {
+      type: DataTypes.DATE,
+      field: 'matched_at'
+    }
+  }, {
+    sequelize,
+    modelName: 'MatchHistory',
+    tableName: 'MatchHistories',
+    timestamps: true
+  });
+
+  return MatchHistory;
+};

--- a/server/routes.js
+++ b/server/routes.js
@@ -13,6 +13,7 @@ const experienceRoutes = require("./features/resume/experience");
 const jobDescriptionRoutes = require("./features/job-description/jobDescription.routes");
 const syncRoutes = require("./features/ml/sync.routes");
 const userManagementRoutes = require("./features/user-management/userManagement.routes");
+const analyticsRoutes = require("./features/analytics/analytics.routes");
 
 router.use("/auth", authRoutes);
 
@@ -30,5 +31,7 @@ router.use("/job-descriptions", jobDescriptionRoutes);
 router.use("/sync", syncRoutes);
 
 router.use("/users", userManagementRoutes);
+
+router.use("/analytics", analyticsRoutes);
 
 module.exports = router;


### PR DESCRIPTION
## Summary

Add analytics dashboard for administrators with platform statistics and match history tracking.

## Changes

### Backend
- **MatchHistory model**: Track resume-job matches with scores
- **Analytics module**: New `analytics` feature with:
  - `GET /api/analytics/dashboard` - Overview stats + top skills
  - `GET /api/analytics/users` - User statistics
  - `GET /api/analytics/jobs` - Job statistics
  - `GET /api/analytics/matches` - Match statistics
- **Match history recording**: Automatically save matches when admin triggers match

### Frontend
- **AnalyticsPage**: Dashboard with:
  - Total users (students/admins breakdown)
  - Active users count
  - Job descriptions count
  - Total matches count
  - Average resume completion percentage
  - Average match score
  - Top 10 skills visualization
- **Navbar**: Analytics link in admin dropdown

### Database
- **MatchHistories table**: Stores job-user matches with scores

## Stats Returned

```javascript
{
  totalUsers, totalStudents, totalAdmins,
  activeUsers, totalJobs, totalMatches,
  avgMatchScore, avgResumeCompletion,
  topSkills: [{ name, count }, ...]
}
```

## Testing

All API tests passed:
- [x] GET /analytics without auth → 401
- [x] GET /analytics with student auth → 403
- [x] GET /analytics with admin auth → 200 + stats
- [x] Match job saves to match history
- [x] Match history reflected in analytics

## Related

Part of: [.opencode/plans/admin-features.md](.opencode/plans/admin-features.md#phase-3-analytics-dashboard)